### PR TITLE
change text color depending on syntax used

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -6,6 +6,7 @@ import Output from './Output';
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
+    overflow: "hidden",
   },
 
   grid: {

--- a/front-end/src/Draft.js
+++ b/front-end/src/Draft.js
@@ -19,8 +19,8 @@ const OPCOMP_REGEX = new RegExp("(?:[\\s]|^)(" + op_comp.join("|") + ")(?=[\\s]|
 const LOOP_REGEX = new RegExp("(?:[\\s]|^)(" + loop.join("|") + ")(?=[\\s]|$)", 'gi')
 const FUNC_REGEX = new RegExp("(?:[\\s]|^)(" + functions.join("|") + ")(?=[\\s]|$)", 'gi')
 
-const DOUBLE_QUOTE_REGEX = /(["'])(?:(?=(\\?))\2.)*?\1/g;
-const SINGLE_QUOTE_REGEX = /([''])(?:(?=(\\?))\2.)*?\1/g;
+const DOUBLE_QUOTE_REGEX = /(["])(?:(?=(\\?))\2.)*?\1/g;
+const SINGLE_QUOTE_REGEX = /(['])(?:(?=(\\?))\2.)*?\1/g;
 
 const Variable = ({ children }) => {
     return (
@@ -72,7 +72,7 @@ const Func = ({ children }) => {
 
 const DoubleQuoteSpan = ({ children }) => {
     return (
-      <span style={{ color: "red" }}>
+      <span style={{ color: "orange" }}>
         {children}
       </span>
     );
@@ -80,7 +80,7 @@ const DoubleQuoteSpan = ({ children }) => {
 
 const SingleQuoteSpan = ({ children }) => {
     return (
-      <span style={{ color: "orange" }}>
+      <span style={{ color: "darkOrange" }}>
         {children}
       </span>
     );

--- a/front-end/src/Draft.js
+++ b/front-end/src/Draft.js
@@ -1,46 +1,201 @@
 import React from 'react';
-import {Editor, EditorState, convertToRaw} from 'draft-js';
-import './editorStyles.css';
+import {Editor, EditorState, convertToRaw, CompositeDecorator} from 'draft-js';
 import { Button } from '@material-ui/core';
 import PlayArrowRoundedIcon from '@material-ui/icons/PlayArrowRounded';
 
-class Draft extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {editorState: EditorState.createEmpty()};;
-        this.onChange = (editorState) => this.setState({editorState});
-        this.setEditor = (editor) => {
-          this.editor = editor;
-        };
-        this.focusEditor = () => {
-          if (this.editor) {
-            this.editor.focus();
-          }
-        };
-        this.run = () => this.props.output(convertToRaw(this.state.editorState.getCurrentContent()));
-    }
-    
-    componentDidMount() {
-        this.focusEditor();
-    }
-    
-    render() {
-        return (
-            <div id="subroot">
-                <Button variant="contained" color="secondary" onClick={this.run}>
-                    <PlayArrowRoundedIcon/>
-                </Button>
-                <div id="editor" onClick={this.focusEditor}>
-                    <Editor
-                    ref={this.setEditor}
-                    editorState={this.state.editorState}
-                    onChange={this.onChange}
-                    />
-                </div>
-            </div>
-        );
+import './editorStyles.css';
+
+const vars = ["num", "bool", "string"];
+const print_statements = ["out", "output", "print"];
+const logic = ["if", "otherwise if", "otherwise", "then", "end if"];
+const op_comp = ["is greater than", "is less than", "is equal to",];
+const loop = ["loop", "until", "end loop"];
+const functions = ["codeblock", "end codeblock"];
+
+const VARS_REGEX = new RegExp("(?:[\\s]|^)(" + vars.join("|") + ")(?=[\\s]|$)", 'gi');
+const PRINT_REGEX = new RegExp("(?:[\\s]|^)(" + print_statements.join("|") + ")(?=[\\s]|$)", 'gi')
+const LOGIC_REGEX = new RegExp("(?:[\\s]|^)(" + logic.join("|") + ")(?=[\\s]|$)", 'gi')
+const OPCOMP_REGEX = new RegExp("(?:[\\s]|^)(" + op_comp.join("|") + ")(?=[\\s]|$)", 'gi')
+const LOOP_REGEX = new RegExp("(?:[\\s]|^)(" + loop.join("|") + ")(?=[\\s]|$)", 'gi')
+const FUNC_REGEX = new RegExp("(?:[\\s]|^)(" + functions.join("|") + ")(?=[\\s]|$)", 'gi')
+
+const DOUBLE_QUOTE_REGEX = /(["'])(?:(?=(\\?))\2.)*?\1/g;
+const SINGLE_QUOTE_REGEX = /([''])(?:(?=(\\?))\2.)*?\1/g;
+
+const Variable = ({ children }) => {
+    return (
+        <span style={{ color:  "lightBlue"}}>
+            {children}
+        </span>
+    );
+};
+
+const Print = ({ children }) => {
+    return (
+        <span style={{ color: "red"}}>
+            {children}
+        </span>
+    );
+};
+
+const Logic = ({ children }) => {
+  return (
+      <span style={{ color: "mediumOrchid"}}>
+          {children}
+      </span>
+  );
+};
+
+const OpComp = ({ children }) => {
+  return (
+      <span style={{ color: "mediumAquaMarine"}}>
+          {children}
+      </span>
+  );
+};
+
+const Loop = ({ children }) => {
+  return (
+      <span style={{ color: "lightSalmon"}}>
+          {children}
+      </span>
+  );
+};
+
+const Func = ({ children }) => {
+  return (
+      <span style={{ color: "gold"}}>
+          {children}
+      </span>
+  );
+};
+
+const DoubleQuoteSpan = ({ children }) => {
+    return (
+      <span style={{ color: "red" }}>
+        {children}
+      </span>
+    );
+};
+
+const SingleQuoteSpan = ({ children }) => {
+    return (
+      <span style={{ color: "orange" }}>
+        {children}
+      </span>
+    );
+};
+
+function findWithRegex(regex, contentBlock, callback) {
+    const text = contentBlock.getText();
+    let matchArr, start;
+    while ((matchArr = regex.exec(text)) !== null) {
+      start = matchArr.index;
+      callback(start, start + matchArr[0].length);
     }
 }
 
-export default Draft;
+function variableStrategy(contentBlock, callback) {
+    findWithRegex(VARS_REGEX, contentBlock, callback);
+}
 
+function printStrategy(contentBlock, callback) {
+    findWithRegex(PRINT_REGEX, contentBlock, callback);
+}
+
+function logicStrategy(contentBlock, callback) {
+  findWithRegex(LOGIC_REGEX, contentBlock, callback);
+}
+
+function opcompStrategy(contentBlock, callback) {
+  findWithRegex(OPCOMP_REGEX, contentBlock, callback);
+}
+
+function loopStrategy(contentBlock, callback) {
+  findWithRegex(LOOP_REGEX, contentBlock, callback);
+}
+
+function funcStrategy(contentBlock, callback) {
+  findWithRegex(FUNC_REGEX, contentBlock, callback);
+}
+
+function doubleQuoteStrategy(contentBlock, callback) {
+    findWithRegex(DOUBLE_QUOTE_REGEX, contentBlock, callback);
+}
+
+function singleQuoteStrategy(contentBlock, callback) {
+    findWithRegex(SINGLE_QUOTE_REGEX, contentBlock, callback);
+}
+
+const createDecorator = () =>
+  new CompositeDecorator([
+    {
+        strategy: variableStrategy,
+        component: Variable
+    },
+    {
+        strategy: printStrategy,
+        component: Print
+    },
+    {
+      strategy: logicStrategy,
+      component: Logic
+    },
+    {
+      strategy: opcompStrategy,
+      component: OpComp
+    },
+    {
+      strategy: loopStrategy,
+      component: Loop
+    },
+    {
+      strategy: funcStrategy,
+      component: Func
+    },
+    { 
+        strategy: doubleQuoteStrategy,
+        component: DoubleQuoteSpan
+    },
+    { 
+        strategy: singleQuoteStrategy,
+        component: SingleQuoteSpan
+    },
+]);
+
+function Draft(props) {
+  const [editorState, setEditorState] = React.useState(
+    EditorState.createEmpty(createDecorator())
+  );
+
+  const editor = React.useRef(null);
+
+  function focusEditor() {
+    editor.current.focus();
+  }
+
+  function run() {
+    props.output(convertToRaw(editorState.getCurrentContent()));
+  }
+
+  React.useEffect(() => {
+    focusEditor()
+  }, []);
+
+  return (
+    <div id="subroot">
+        <Button variant="contained" color="secondary" onClick={run}>
+            <PlayArrowRoundedIcon/>
+        </Button>
+        <div id="editor" onClick={focusEditor}>
+            <Editor
+            ref={editor}
+            editorState={editorState}
+            onChange={editorState => setEditorState(editorState)}
+            />
+        </div>
+    </div>
+  );
+}
+
+export default Draft;

--- a/front-end/src/editorStyles.css
+++ b/front-end/src/editorStyles.css
@@ -9,4 +9,5 @@ div.DraftEditor-editorContainer,
 div.public-DraftEditor-content {
     height: 100%;
     padding: 10px 0px 0px 0px;
+    font-size: 20px;
 }


### PR DESCRIPTION
#16 
![syntax](https://user-images.githubusercontent.com/20798367/74804332-ec918100-52ad-11ea-8391-311b57143e12.png)
above syntax is now detected and changes color depending on what it is. Syntax was pulled from Pharos design doc.
Double quotes and single quotes work too!
